### PR TITLE
Use api key header as password

### DIFF
--- a/pkg/webserver/start.go
+++ b/pkg/webserver/start.go
@@ -172,7 +172,7 @@ func (s *server) startWebServer() error {
 	s.HandleFunc("/auth", s.handleDelSrv).Methods(http.MethodDelete).Headers("X-Server", "")
 	// nginx handlers
 	s.HandleFunc("/auth", s.handleServer).Methods(http.MethodGet, http.MethodHead).
-		Headers("X-Server", "", "X-Password", s.Password)
+		Headers("X-Server", "", "X-API-Key", s.Password)
 	s.Handle("/auth", s.parseAPIKey(http.HandlerFunc(s.handleGetKey))).
 		Methods(http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut)
 	s.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
The password was removed from the [nodebot](https://github.com/Notifiarr/nodebot), and an internal API key added to allow it to auth through the proxy. We thought that was groovy, so I removed the [server code](https://github.com/Notifiarr/mysql-auth-proxy/pull/84). 
The problem is that all server requests now go to whatever environment that internal api key is assigned. So we [put the server code back](https://github.com/Notifiarr/mysql-auth-proxy/pull/86). That didn't fix the problem, but we're hoping this minor change does. We configure this with the internal api key as the password and that should pass requests to the proper environment for the server.