### PR TITLE
Remove gorilla mux, replace with stdlib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ server {
     auth_request_set $auth_idnt $upstream_http_X_UserID;
 
     proxy_set_header host $redirect_host;
-    proxy_set_header x-api-key $remote_api_key;
+    proxy_set_header X-Api-Key $remote_api_key;
     proxy_pass $server$request_uri;
   }
 
@@ -68,7 +68,7 @@ server {
     proxy_pass_request_body off;
     proxy_set_header Content-Length "";
     proxy_set_header X-Original-URI $request_uri;
-    proxy_set_header X-API-Key $incoming_api_key;
+    proxy_set_header X-Api-Key $incoming_api_key;
     proxy_set_header X-Server $http_X_Server;
     proxy_pass $authproxy/auth;
   }

--- a/docs/api_docs.go
+++ b/docs/api_docs.go
@@ -17,7 +17,7 @@ const docTemplateapi = `{
     "paths": {
         "/auth": {
             "get": {
-                "description": "Retrieve the environment for an API Key or Server ID. This endpoint is designed for auth proxy requests from Nginx.\nOne of X-Server, X-API-Key or X-Original-URI (with an api key in it) must be provided.",
+                "description": "Retrieve the environment for an API Key or Server ID. This endpoint is designed for auth proxy requests from Nginx.\nOne of X-Server, X-Api-Key or X-Original-URI (with an api key in it) must be provided.",
                 "tags": [
                     "auth"
                 ],
@@ -38,7 +38,7 @@ const docTemplateapi = `{
                     {
                         "type": "string",
                         "description": "User's API Key to route. May also be provided in X-Original-URI header.",
-                        "name": "X-API-Key",
+                        "name": "X-Api-Key",
                         "in": "header"
                     },
                     {
@@ -56,7 +56,7 @@ const docTemplateapi = `{
                                 "type": "string",
                                 "description": "How long this information has been in the cache."
                             },
-                            "X-API-Key": {
+                            "X-Api-Key": {
                                 "type": "string",
                                 "description": "API Key parsed from request."
                             },
@@ -80,7 +80,7 @@ const docTemplateapi = `{
                             "type": "string"
                         },
                         "headers": {
-                            "X-API-Key": {
+                            "X-Api-Key": {
                                 "type": "string",
                                 "description": "API Key parsed from request."
                             }
@@ -108,7 +108,7 @@ const docTemplateapi = `{
                     {
                         "type": "string",
                         "description": "Comma separated list of API keys to delete.",
-                        "name": "X-API-Keys",
+                        "name": "X-Api-Keys",
                         "in": "header",
                         "required": true
                     }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.1
 
 require (
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/gorilla/mux v1.8.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/swaggo/swag v1.16.6
 	golift.io/cache v1.0.1-0.20260406025202-1176587c97ab

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/exp/metrics.go
+++ b/pkg/exp/metrics.go
@@ -143,3 +143,22 @@ func warmHTTPMetrics(metrics *Metrics) {
 		metrics.HTTPResponse.WithLabelValues(strconv.Itoa(code))
 	}
 }
+
+// CountRequest increments the appropriate HTTP request and response metrics for a web request.
+func (m *Metrics) CountRequest(req *http.Request, statusCode string) {
+	if m == nil {
+		return
+	}
+
+	m.HTTPRequests.WithLabelValues(HTTPEventTotal).Inc()
+
+	if req.Method == http.MethodDelete {
+		m.HTTPRequests.WithLabelValues(HTTPEventDelete).Inc()
+	}
+
+	if _, ok := req.Header["X-Server"]; ok {
+		m.HTTPRequests.WithLabelValues(HTTPEventXServer).Inc()
+	}
+
+	m.HTTPResponse.WithLabelValues(statusCode).Inc()
+}

--- a/pkg/exp/metrics.go
+++ b/pkg/exp/metrics.go
@@ -156,7 +156,7 @@ func (m *Metrics) CountRequest(req *http.Request, statusCode string) {
 		m.HTTPRequests.WithLabelValues(HTTPEventDelete).Inc()
 	}
 
-	if _, ok := req.Header["X-Server"]; ok {
+	if len(req.Header["X-Server"]) > 0 {
 		m.HTTPRequests.WithLabelValues(HTTPEventXServer).Inc()
 	}
 

--- a/pkg/webserver/accesslog.go
+++ b/pkg/webserver/accesslog.go
@@ -50,17 +50,6 @@ func (c *captureWriter) statusCode() int {
 	return c.status
 }
 
-// Get returns the first value for a response header field. key must already be in
-// canonical form (http.CanonicalHeaderKey). Unlike Header.Get it does not allocate
-// or re-canonicalize key on each call.
-func (c *captureWriter) Get(key string) string {
-	if v := c.Header()[key]; len(v) > 0 {
-		return v[0]
-	}
-
-	return ""
-}
-
 //nolint:gochecknoglobals // one pool per process for hot-path access log strings.Builder reuse
 var alBuilder = sync.Pool{New: func() any { return &strings.Builder{} }}
 
@@ -93,10 +82,10 @@ func (c *captureWriter) writeAccessLogLinePrefix(builder *strings.Builder, req *
 	builder.WriteByte(' ')
 	// "%{X-Username}o"
 	builder.WriteByte('"')
-	builder.WriteString(c.Get("X-Username"))
+	builder.WriteString(getHeader(req.Header, "X-Username"))
 	builder.WriteString("\" ")
 	// %{X-UserID}o
-	builder.WriteString(c.Get("X-Userid"))
+	builder.WriteString(getHeader(req.Header, "X-Userid"))
 	builder.WriteByte(' ')
 	// %t — [02/Jan/2006:15:04:05 -0700]
 	builder.WriteByte('[')
@@ -134,9 +123,9 @@ func (c *captureWriter) writeAccessLogLineTail(builder *strings.Builder, req *ht
 	// %{ms}T — elapsed milliseconds (same as apache-logformat request duration).
 	builder.WriteString(strconv.FormatInt(time.Since(c.start).Milliseconds(), 10))
 	builder.WriteString("ms age:")
-	builder.WriteString(c.Get("Age"))
+	builder.WriteString(getHeader(req.Header, "Age"))
 	builder.WriteString(" env:")
-	builder.WriteString(c.Get("X-Environment"))
+	builder.WriteString(getHeader(req.Header, "X-Environment"))
 	builder.WriteString(" key:")
 
 	masked, keyLenStr := c.maskedAPIKeyFromResponse()
@@ -144,14 +133,14 @@ func (c *captureWriter) writeAccessLogLineTail(builder *strings.Builder, req *ht
 	builder.WriteByte('(')
 	builder.WriteString(keyLenStr)
 	builder.WriteString(") \"srv:")
-	builder.WriteString(req.Header.Get("X-Server"))
+	builder.WriteString(getHeader(req.Header, "X-Server"))
 	builder.WriteString("\"\n")
 }
 
 // maskedAPIKeyFromResponse returns maskAPIKey(w X-Api-Key) for the access log, or ("", "")
 // when the handler did not set that response header.
 func (c *captureWriter) maskedAPIKeyFromResponse() (string, string) {
-	key := c.Get("X-Api-Key")
+	key := getHeader(c.Header(), "X-Api-Key")
 	if key == "" {
 		return "", ""
 	}
@@ -164,7 +153,7 @@ func (c *captureWriter) maskedAPIKeyFromResponse() (string, string) {
 // If the path has fewer than keyPosition+1 segments, it returns the full path (still without query).
 // When X-Original-Uri is missing, empty, or only a query string, it returns "".
 func RefererPathForLog(header http.Header) string {
-	pathPart, _, _ := strings.Cut(header.Get("X-Original-Uri"), "?")
+	pathPart, _, _ := strings.Cut(getHeader(header, "X-Original-Uri"), "?")
 	if pathPart == "" {
 		return ""
 	}
@@ -189,7 +178,7 @@ func RefererPathForLog(header http.Header) string {
 
 // ClientIPForLog returns the client IP for access logs (same rules as the former fixForwardedFor middleware).
 func ClientIPForLog(req *http.Request) string {
-	forwarded := req.Header.Get("X-Forwarded-For")
+	forwarded := getHeader(req.Header, "X-Forwarded-For")
 	if forwarded == "" {
 		host, _, err := net.SplitHostPort(req.RemoteAddr)
 		if err != nil {

--- a/pkg/webserver/accesslog.go
+++ b/pkg/webserver/accesslog.go
@@ -24,7 +24,7 @@ type captureWriter struct {
 }
 
 func (c *captureWriter) WriteHeader(code int) {
-	if c.status == 0 {
+	if c.status == 0 { // cannot set it twice.
 		c.status = code
 	}
 
@@ -32,7 +32,7 @@ func (c *captureWriter) WriteHeader(code int) {
 }
 
 func (c *captureWriter) Write(p []byte) (int, error) {
-	if c.status == 0 {
+	if c.status == 0 { // if you write without setting the status, it's a 200.
 		c.status = http.StatusOK
 	}
 
@@ -42,25 +42,28 @@ func (c *captureWriter) Write(p []byte) (int, error) {
 	return n, err //nolint:wrapcheck // delegate to underlying ResponseWriter
 }
 
-func (c *captureWriter) statusCode() int {
+func (c *captureWriter) statusCode() string {
 	if c.status == 0 {
-		return http.StatusOK
+		return "200"
 	}
 
-	return c.status
+	return strconv.Itoa(c.status)
+}
+
+// accessLogWrap writes one Apache-style line per request to dst (same field order as the former alFmt)
+// and records HTTP request/response Prometheus counters when metrics is non-nil.
+func (s *server) accessLogWrap(next http.Handler, dst io.Writer) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		capture := &captureWriter{ResponseWriter: resp, start: time.Now()}
+		next.ServeHTTP(capture, req)
+		capture.writeAccessLogLine(req, dst)
+		// Update Prometheus metrics for the request.
+		s.metrics.CountRequest(req, capture.statusCode())
+	})
 }
 
 //nolint:gochecknoglobals // one pool per process for hot-path access log strings.Builder reuse
 var alBuilder = sync.Pool{New: func() any { return &strings.Builder{} }}
-
-// accessLogWrap writes one Apache-style line per request to dst (same field order as the former alFmt).
-func accessLogWrap(next http.Handler, dst io.Writer) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		capture := &captureWriter{ResponseWriter: w, start: time.Now()}
-		next.ServeHTTP(capture, req)
-		capture.writeAccessLogLine(req, dst)
-	})
-}
 
 func (c *captureWriter) writeAccessLogLine(req *http.Request, dst io.Writer) {
 	//nolint:forcetypeassert
@@ -74,6 +77,7 @@ func (c *captureWriter) writeAccessLogLine(req *http.Request, dst io.Writer) {
 }
 
 func (c *captureWriter) writeAccessLogLinePrefix(builder *strings.Builder, req *http.Request) {
+	respHeader := c.Header()
 	// %V
 	builder.WriteString(req.Host)
 	builder.WriteByte(' ')
@@ -82,10 +86,10 @@ func (c *captureWriter) writeAccessLogLinePrefix(builder *strings.Builder, req *
 	builder.WriteByte(' ')
 	// "%{X-Username}o"
 	builder.WriteByte('"')
-	builder.WriteString(getHeader(req.Header, "X-Username"))
+	builder.WriteString(getHeader(respHeader, HeaderXUsername))
 	builder.WriteString("\" ")
 	// %{X-UserID}o
-	builder.WriteString(getHeader(req.Header, "X-Userid"))
+	builder.WriteString(getHeader(respHeader, HeaderXUserid))
 	builder.WriteByte(' ')
 	// %t — [02/Jan/2006:15:04:05 -0700]
 	builder.WriteByte('[')
@@ -104,7 +108,7 @@ func (c *captureWriter) writeAccessLogLinePrefix(builder *strings.Builder, req *
 
 	builder.WriteString(" HTTP/1.1\" ")
 	// %>s
-	builder.WriteString(strconv.Itoa(c.statusCode()))
+	builder.WriteString(c.statusCode())
 	builder.WriteByte(' ')
 	// %b — response body size (0 when none).
 	builder.WriteString(strconv.FormatInt(c.size, 10))
@@ -119,28 +123,33 @@ func (c *captureWriter) writeAccessLogLinePrefix(builder *strings.Builder, req *
 }
 
 func (c *captureWriter) writeAccessLogLineTail(builder *strings.Builder, req *http.Request) {
+	respHeader := c.Header()
 	builder.WriteString(" req:")
 	// %{ms}T — elapsed milliseconds (same as apache-logformat request duration).
 	builder.WriteString(strconv.FormatInt(time.Since(c.start).Milliseconds(), 10))
 	builder.WriteString("ms age:")
-	builder.WriteString(getHeader(req.Header, "Age"))
+	builder.WriteString(getHeader(respHeader, HeaderAge))
 	builder.WriteString(" env:")
-	builder.WriteString(getHeader(req.Header, "X-Environment"))
+	builder.WriteString(getHeader(respHeader, HeaderEnvironment))
 	builder.WriteString(" key:")
 
-	masked, keyLenStr := c.maskedAPIKeyFromResponse()
+	masked, keyLenStr := maskedAPIKeyForLog(req, respHeader)
 	builder.WriteString(masked)
 	builder.WriteByte('(')
 	builder.WriteString(keyLenStr)
 	builder.WriteString(") \"srv:")
-	builder.WriteString(getHeader(req.Header, "X-Server"))
+	builder.WriteString(getHeader(req.Header, HeaderXServer))
 	builder.WriteString("\"\n")
 }
 
-// maskedAPIKeyFromResponse returns maskAPIKey(w X-Api-Key) for the access log, or ("", "")
-// when the handler did not set that response header.
-func (c *captureWriter) maskedAPIKeyFromResponse() (string, string) {
-	key := getHeader(c.Header(), "X-Api-Key")
+// maskedAPIKeyForLog returns maskAPIKey(X-Api-Key) from the response, else from the parsed request
+// context, or ("", "") if neither is set.
+func maskedAPIKeyForLog(req *http.Request, resp http.Header) (string, string) {
+	key := getHeader(resp, HeaderXAPIKey)
+	if key == "" {
+		key = apiKeyFromRequest(req)
+	}
+
 	if key == "" {
 		return "", ""
 	}
@@ -153,7 +162,7 @@ func (c *captureWriter) maskedAPIKeyFromResponse() (string, string) {
 // If the path has fewer than keyPosition+1 segments, it returns the full path (still without query).
 // When X-Original-Uri is missing, empty, or only a query string, it returns "".
 func RefererPathForLog(header http.Header) string {
-	pathPart, _, _ := strings.Cut(getHeader(header, "X-Original-Uri"), "?")
+	pathPart, _, _ := strings.Cut(getHeader(header, HeaderXOriginalURI), "?")
 	if pathPart == "" {
 		return ""
 	}
@@ -178,7 +187,7 @@ func RefererPathForLog(header http.Header) string {
 
 // ClientIPForLog returns the client IP for access logs (same rules as the former fixForwardedFor middleware).
 func ClientIPForLog(req *http.Request) string {
-	forwarded := getHeader(req.Header, "X-Forwarded-For")
+	forwarded := getHeader(req.Header, HeaderXForwardedFor)
 	if forwarded == "" {
 		host, _, err := net.SplitHostPort(req.RemoteAddr)
 		if err != nil {

--- a/pkg/webserver/accesslog_internal_test.go
+++ b/pkg/webserver/accesslog_internal_test.go
@@ -28,8 +28,8 @@ func TestResponseWriter(t *testing.T) {
 	rec := httptest.NewRecorder()
 	capWriter := &captureWriter{ResponseWriter: rec}
 
-	if capWriter.statusCode() != http.StatusOK {
-		t.Fatalf("statusCode before any write = %d, want 200", capWriter.statusCode())
+	if capWriter.statusCode() != "200" {
+		t.Fatalf("statusCode before any write = %s, want 200", capWriter.statusCode())
 	}
 
 	capWriter.WriteHeader(http.StatusTeapot)
@@ -57,8 +57,8 @@ func TestResponseWriter(t *testing.T) {
 		t.Fatalf("size = %d, want 2", capWriter.size)
 	}
 
-	if capWriter.statusCode() != http.StatusTeapot {
-		t.Fatalf("statusCode = %d, want %d", capWriter.statusCode(), http.StatusTeapot)
+	if capWriter.statusCode() != "418" {
+		t.Fatalf("statusCode = %s, want 418", capWriter.statusCode())
 	}
 }
 
@@ -77,8 +77,8 @@ func TestResponseWriter_WriteImpliesOK(t *testing.T) {
 		t.Fatalf("Write without WriteHeader: status = %d, want 200", capWriter.status)
 	}
 
-	if capWriter.statusCode() != http.StatusOK {
-		t.Fatalf("statusCode = %d, want 200", capWriter.statusCode())
+	if capWriter.statusCode() != "200" {
+		t.Fatalf("statusCode = %s, want 200", capWriter.statusCode())
 	}
 }
 
@@ -91,16 +91,16 @@ func TestWriteAccessLogLine(t *testing.T) {
 	req.RequestURI = "/p?q=1"
 	req.RemoteAddr = "192.0.2.1:9999"
 	req.Header.Set("User-Agent", "test-agent/1")
-	req.Header.Set("X-Server", "srv-99")
-	req.Header.Set("X-Original-Uri", "/api/v1/route/method/"+TestAccessLogAPIKey)
+	req.Header.Set(HeaderXServer, "srv-99")
+	req.Header.Set(HeaderXOriginalURI, "/api/v1/route/method/"+TestAccessLogAPIKey)
 
 	rec := httptest.NewRecorder()
 	capWriter := &captureWriter{ResponseWriter: rec}
 	capWriter.start = time.Now().Add(-elapsed)
-	capWriter.Header().Set("X-Username", "alice")
-	capWriter.Header().Set("X-Userid", "1001")
-	capWriter.Header().Set("Age", "60")
-	capWriter.Header().Set("X-Environment", "live")
+	capWriter.Header().Set(HeaderXUsername, "alice")
+	capWriter.Header().Set(HeaderXUserid, "1001")
+	capWriter.Header().Set(HeaderAge, "60")
+	capWriter.Header().Set(HeaderEnvironment, "live")
 	capWriter.WriteHeader(http.StatusOK)
 	_, _ = capWriter.Write([]byte("body"))
 
@@ -168,12 +168,12 @@ func TestWriteAccessLogLine_MaskedKeyFromResponseHeader(t *testing.T) {
 
 	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://x/", nil)
-	req.Header.Set("X-Server", "")
+	req.Header.Set(HeaderXServer, "")
 
 	rec := httptest.NewRecorder()
 	capWriter := &captureWriter{ResponseWriter: rec}
 	capWriter.start = start
-	capWriter.Header().Set("X-Api-Key", TestAccessLogAPIKey)
+	capWriter.Header().Set(HeaderXAPIKey, TestAccessLogAPIKey)
 
 	builder := &strings.Builder{}
 
@@ -210,19 +210,20 @@ func TestAccessLogWrap(t *testing.T) {
 
 	var dst bytes.Buffer
 
-	handler := accessLogWrap(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
-		resp.Header().Set("X-Username", "wrap-user")
-		resp.Header().Set("X-Userid", "55")
-		resp.Header().Set("Age", "3")
-		resp.Header().Set("X-Environment", "dev")
+	srv := &server{}
+	handler := srv.accessLogWrap(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+		resp.Header().Set(HeaderXUsername, "wrap-user")
+		resp.Header().Set(HeaderXUserid, "55")
+		resp.Header().Set(HeaderAge, "3")
+		resp.Header().Set(HeaderEnvironment, "dev")
 		resp.WriteHeader(http.StatusNoContent)
 	}), &dst)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://proxy.test/auth", nil)
 	req.RequestURI = "/auth"
 	req.RemoteAddr = "198.51.100.2:4444"
-	req.Header.Set("X-Forwarded-For", "203.0.113.5")
-	req.Header.Set("X-Server", "discord-srv")
+	req.Header.Set(HeaderXForwardedFor, "203.0.113.5")
+	req.Header.Set(HeaderXServer, "discord-srv")
 	req.Header.Set("User-Agent", "ua-wrap")
 
 	rec := httptest.NewRecorder()
@@ -255,8 +256,9 @@ func TestAccessLogWrap_MaskedKeyFromResponseHeader(t *testing.T) {
 
 	var dst bytes.Buffer
 
-	handler := accessLogWrap(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
-		resp.Header().Set("X-Api-Key", TestAccessLogAPIKey)
+	srv := &server{}
+	handler := srv.accessLogWrap(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+		resp.Header().Set(HeaderXAPIKey, TestAccessLogAPIKey)
 		resp.WriteHeader(http.StatusUnauthorized)
 	}), &dst)
 

--- a/pkg/webserver/accesslog_test.go
+++ b/pkg/webserver/accesslog_test.go
@@ -51,7 +51,7 @@ func TestRefererPathForLog(t *testing.T) {
 			t.Parallel()
 
 			h := http.Header{}
-			h.Set("X-Original-Uri", testCase.origURI)
+			h.Set(webserver.HeaderXOriginalURI, testCase.origURI)
 
 			if got := webserver.RefererPathForLog(h); got != testCase.want {
 				t.Fatalf("RefererPathForLog = %q, want %q (X-Original-Uri=%q)", got, testCase.want, testCase.origURI)
@@ -74,7 +74,7 @@ func TestClientIPForLog(t *testing.T) {
 		t.Fatalf("ClientIPForLog = %q, want 192.0.2.1", got)
 	}
 
-	req.Header.Set("X-Forwarded-For", " 203.0.113.9 , 198.51.100.1 ")
+	req.Header.Set(webserver.HeaderXForwardedFor, " 203.0.113.9 , 198.51.100.1 ")
 
 	if got := webserver.ClientIPForLog(req); got != "203.0.113.9" {
 		t.Fatalf("ClientIPForLog with XFF = %q, want 203.0.113.9", got)

--- a/pkg/webserver/functions.go
+++ b/pkg/webserver/functions.go
@@ -2,20 +2,20 @@
 package webserver
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/Notifiarr/mysql-auth-proxy/pkg/exp"
-	"github.com/gorilla/mux"
 )
 
 const (
-	keyLength = 36       // exact key length for a valid key.
-	apiKey    = "apiKey" // used for map key internally.
-	// website uses this position for the api key, e.g. /api/v1/route/method/{apikey} <-- 5.
-	keyPosition = 5
+	keyLength   = 36 // exact key length for a valid key.
+	keyPosition = 5  // website uses this position for the api key, e.g. /api/v1/route/method/{apikey} <-- 5.
 )
+
+type parsedAPIKeyCtxKey struct{}
 
 // GetAPIKeyFromURIPath returns segment keyPosition of strings.Split(pathStr, "/") (without
 // allocating the split slice). If that segment contains "?", only the part before it is returned.
@@ -33,6 +33,12 @@ func GetAPIKeyFromURIPath(pathStr string) string {
 	}
 
 	return ""
+}
+
+// apiKeyFromRequest returns the parsed API key set by parseAPIKey (empty if unset).
+func apiKeyFromRequest(req *http.Request) string {
+	v, _ := req.Context().Value(parsedAPIKeyCtxKey{}).(string)
+	return v
 }
 
 type responseWrapper struct {
@@ -54,7 +60,7 @@ func (s *server) countRequests(next http.Handler) http.Handler {
 			s.metrics.HTTPRequests.WithLabelValues(exp.HTTPEventDelete).Inc()
 		}
 
-		if req.Header.Get("X-Server") != "" {
+		if getHeader(req.Header, "X-Server") != "" {
 			s.metrics.HTTPRequests.WithLabelValues(exp.HTTPEventXServer).Inc()
 		}
 
@@ -65,29 +71,16 @@ func (s *server) countRequests(next http.Handler) http.Handler {
 	})
 }
 
-// parseAPIKey sets a valid-lengh api key to a mux var.
+// parseAPIKey attaches the parsed API key to req's context for downstream handlers,
 // or returns a 401 if no key is found.
 func (s *server) parseAPIKey(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		key := req.Header.Get("X-Api-Key")
+		key := getHeader(req.Header, "X-Api-Key")
 		if len(key) != keyLength {
-			key = GetAPIKeyFromURIPath(req.Header.Get("X-Original-Uri"))
+			key = GetAPIKeyFromURIPath(getHeader(req.Header, "X-Original-Uri"))
 		}
 
-		pooled := s.apiKeyVarsPool.Get()
-
-		urlVars, ok := pooled.(map[string]string)
-		if !ok {
-			urlVars = make(map[string]string, 1)
-		}
-
-		urlVars[apiKey] = key
-		req = mux.SetURLVars(req, urlVars)
-
-		defer func() {
-			delete(urlVars, apiKey)
-			s.apiKeyVarsPool.Put(urlVars)
-		}()
+		req = req.WithContext(context.WithValue(req.Context(), parsedAPIKeyCtxKey{}, key))
 
 		if len(key) != keyLength {
 			s.metrics.HTTPRequests.WithLabelValues(exp.HTTPEventInvalidKey).Inc()
@@ -107,4 +100,15 @@ func maskAPIKey(key string) (string, string) {
 	}
 
 	return key[:4] + "..." + key[length-2:], strconv.Itoa(length)
+}
+
+// getHeader returns the first value for an http.Header field. key must already be in
+// canonical form (http.CanonicalHeaderKey). Unlike Header.Get it does not allocate
+// or re-canonicalize key on each call.
+func getHeader(headers http.Header, key string) string {
+	if v := headers[key]; len(v) > 0 {
+		return v[0]
+	}
+
+	return ""
 }

--- a/pkg/webserver/functions.go
+++ b/pkg/webserver/functions.go
@@ -41,43 +41,13 @@ func apiKeyFromRequest(req *http.Request) string {
 	return v
 }
 
-type responseWrapper struct {
-	http.ResponseWriter
-
-	statusCode int
-}
-
-func (r *responseWrapper) WriteHeader(statusCode int) {
-	r.statusCode = statusCode
-	r.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (s *server) countRequests(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		s.metrics.HTTPRequests.WithLabelValues(exp.HTTPEventTotal).Inc()
-
-		if req.Method == http.MethodDelete {
-			s.metrics.HTTPRequests.WithLabelValues(exp.HTTPEventDelete).Inc()
-		}
-
-		if getHeader(req.Header, "X-Server") != "" {
-			s.metrics.HTTPRequests.WithLabelValues(exp.HTTPEventXServer).Inc()
-		}
-
-		wrap := &responseWrapper{ResponseWriter: resp, statusCode: http.StatusOK}
-		next.ServeHTTP(wrap, req)
-
-		s.metrics.HTTPResponse.WithLabelValues(strconv.Itoa(wrap.statusCode)).Inc()
-	})
-}
-
 // parseAPIKey attaches the parsed API key to req's context for downstream handlers,
 // or returns a 401 if no key is found.
 func (s *server) parseAPIKey(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		key := getHeader(req.Header, "X-Api-Key")
+		key := getHeader(req.Header, HeaderXAPIKey)
 		if len(key) != keyLength {
-			key = GetAPIKeyFromURIPath(getHeader(req.Header, "X-Original-Uri"))
+			key = GetAPIKeyFromURIPath(getHeader(req.Header, HeaderXOriginalURI))
 		}
 
 		req = req.WithContext(context.WithValue(req.Context(), parsedAPIKeyCtxKey{}, key))

--- a/pkg/webserver/handlers_delete.go
+++ b/pkg/webserver/handlers_delete.go
@@ -29,7 +29,7 @@ type noExists struct {
 func (s *server) handleDelSrv(resp http.ResponseWriter, req *http.Request) {
 	user := userinfo.DefaultUser()
 
-	serverID := getHeader(req.Header, "X-Server")
+	serverID := getHeader(req.Header, HeaderXServer)
 
 	item := s.servers.Get(serverID)
 	if item != nil && item.Data != nil {
@@ -42,13 +42,13 @@ func (s *server) handleDelSrv(resp http.ResponseWriter, req *http.Request) {
 
 	// These headers are mostly for logs.
 	if user != nil && user.UserID != userinfo.DefaultUserID {
-		resp.Header().Set("X-Userid", user.UserID)
-		resp.Header().Set("X-Username", user.Username)
+		resp.Header().Set(HeaderXUserid, user.UserID)
+		resp.Header().Set(HeaderXUsername, user.Username)
 	}
 
-	resp.Header().Set("X-Environment", "deleted")
-	resp.Header().Set("Content-Type", "application/json")
-	resp.Header().Set("Age", "1")
+	resp.Header().Set(HeaderEnvironment, "deleted")
+	resp.Header().Set(HeaderContentType, "application/json")
+	resp.Header().Set(HeaderAge, "1")
 
 	var reply any = noExists{}
 	if item != nil {
@@ -65,7 +65,7 @@ func (s *server) handleDelSrv(resp http.ResponseWriter, req *http.Request) {
 }
 
 func (s *server) handleDelKey(resp http.ResponseWriter, req *http.Request) {
-	keys := strings.Split(getHeader(req.Header, "X-Api-Keys"), ",")
+	keys := strings.Split(getHeader(req.Header, HeaderXAPIKeys), ",")
 	infos := make([]*cache.Item, len(keys))
 	user := userinfo.DefaultUser()
 
@@ -79,14 +79,14 @@ func (s *server) handleDelKey(resp http.ResponseWriter, req *http.Request) {
 
 		// Something is better than nothing.
 		if user != nil && user.UserID != userinfo.DefaultUserID {
-			resp.Header().Set("X-Userid", user.UserID)
-			resp.Header().Set("X-Username", user.Username)
+			resp.Header().Set(HeaderXUserid, user.UserID)
+			resp.Header().Set(HeaderXUsername, user.Username)
 		}
 	}
 
-	resp.Header().Set("X-Environment", "deleted")
-	resp.Header().Set("Content-Type", "application/json")
-	resp.Header().Set("Age", strconv.Itoa(len(infos)))
+	resp.Header().Set(HeaderEnvironment, "deleted")
+	resp.Header().Set(HeaderContentType, "application/json")
+	resp.Header().Set(HeaderAge, strconv.Itoa(len(infos)))
 	resp.WriteHeader(http.StatusOK)
 
 	err := json.NewEncoder(resp).Encode(infos)

--- a/pkg/webserver/handlers_delete.go
+++ b/pkg/webserver/handlers_delete.go
@@ -21,7 +21,7 @@ type noExists struct {
 // @Tags         auth
 // @Produce      json
 // @Param        X-Server   header string true "Discord Server ID to delete."
-// @Param        X-API-Keys header string true "Comma separated list of API keys to delete."
+// @Param        X-Api-Keys header string true "Comma separated list of API keys to delete."
 // @Success      200  {object} []cache.Item{data=userinfo.UserInfo} "List of cached info for API Keys or servers that were deleted."
 // @Success      208  {object} noExists "exists: false is returned when a missing server ID is provided."
 // @Failure      401  {object} string "invalid request"
@@ -29,7 +29,7 @@ type noExists struct {
 func (s *server) handleDelSrv(resp http.ResponseWriter, req *http.Request) {
 	user := userinfo.DefaultUser()
 
-	serverID := req.Header.Get("X-Server")
+	serverID := getHeader(req.Header, "X-Server")
 
 	item := s.servers.Get(serverID)
 	if item != nil && item.Data != nil {
@@ -65,7 +65,7 @@ func (s *server) handleDelSrv(resp http.ResponseWriter, req *http.Request) {
 }
 
 func (s *server) handleDelKey(resp http.ResponseWriter, req *http.Request) {
-	keys := strings.Split(req.Header.Get("X-Api-Keys"), ",")
+	keys := strings.Split(getHeader(req.Header, "X-Api-Keys"), ",")
 	infos := make([]*cache.Item, len(keys))
 	user := userinfo.DefaultUser()
 

--- a/pkg/webserver/handlers_nginx.go
+++ b/pkg/webserver/handlers_nginx.go
@@ -115,11 +115,11 @@ func (s *server) writeAuthResult(
 ) {
 	finished := time.Now()
 	s.metrics.ReqTime.WithLabelValues(label).Observe(finished.Sub(start).Seconds())
-	resp.Header().Set("X-Api-Key", user.APIKey)
-	resp.Header().Set("X-Environment", user.Environment)
-	resp.Header().Set("X-Username", user.Username)
-	resp.Header().Set("X-Userid", user.UserID)
-	resp.Header().Set("Age", strconv.Itoa(int(finished.Sub(when).Seconds())))
+	resp.Header().Set(HeaderXAPIKey, user.APIKey)
+	resp.Header().Set(HeaderEnvironment, user.Environment)
+	resp.Header().Set(HeaderXUsername, user.Username)
+	resp.Header().Set(HeaderXUserid, user.UserID)
+	resp.Header().Set(HeaderAge, strconv.Itoa(int(finished.Sub(when).Seconds())))
 	// If the user is the default user, and there was no error, then return a 401.
 	if user.UserID == userinfo.DefaultUserID && (err == nil || errors.Is(err, userinfo.ErrNoUser)) {
 		s.noKeyReply(resp, req)
@@ -131,9 +131,9 @@ func (s *server) writeAuthResult(
 
 // noKeyReply returns a 401.
 func (s *server) noKeyReply(resp http.ResponseWriter, req *http.Request) {
-	resp.Header().Set("X-Api-Key", apiKeyFromRequest(req))
+	resp.Header().Set(HeaderXAPIKey, apiKeyFromRequest(req))
 
-	if s.RequiresAPIKey(getHeader(req.Header, "X-Original-Uri")) {
+	if s.RequiresAPIKey(getHeader(req.Header, HeaderXOriginalURI)) {
 		resp.WriteHeader(http.StatusUnauthorized)
 	} else {
 		resp.WriteHeader(http.StatusOK)
@@ -144,19 +144,19 @@ func (s *server) noKeyReply(resp http.ResponseWriter, req *http.Request) {
 func (s *server) handleAuth(resp http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case http.MethodDelete:
-		if getHeader(req.Header, "X-Api-Keys") != "" {
+		if getHeader(req.Header, HeaderXAPIKeys) != "" {
 			s.handleDelKey(resp, req)
 			return
 		}
 
-		if getHeader(req.Header, "X-Server") != "" {
+		if getHeader(req.Header, HeaderXServer) != "" {
 			s.handleDelSrv(resp, req)
 			return
 		}
 
 		http.NotFound(resp, req)
 	case http.MethodGet, http.MethodHead:
-		if getHeader(req.Header, "X-Server") != "" && getHeader(req.Header, "X-Api-Key") == s.Password {
+		if getHeader(req.Header, HeaderXServer) != "" && getHeader(req.Header, HeaderXAPIKey) == s.Password {
 			s.handleServer(resp, req)
 			return
 		}

--- a/pkg/webserver/handlers_nginx.go
+++ b/pkg/webserver/handlers_nginx.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Notifiarr/mysql-auth-proxy/pkg/userinfo"
-	"github.com/gorilla/mux"
 	"golift.io/cache"
 )
 
@@ -38,7 +37,7 @@ func cacheUserFromGetInto(store *cache.Cache, key string) (*userinfo.UserInfo, t
 }
 
 func (s *server) handleServer(resp http.ResponseWriter, req *http.Request) {
-	key := req.Header.Get("X-Server")
+	key := getHeader(req.Header, "X-Server")
 	s.handleGetAny(resp, req, keyReq{
 		label: "servers",
 		key:   key,
@@ -49,7 +48,7 @@ func (s *server) handleServer(resp http.ResponseWriter, req *http.Request) {
 }
 
 func (s *server) handleGetKey(resp http.ResponseWriter, req *http.Request) {
-	key := mux.Vars(req)[apiKey]
+	key := apiKeyFromRequest(req)
 	s.handleGetAny(resp, req, keyReq{
 		label: "users",
 		key:   key,
@@ -60,21 +59,21 @@ func (s *server) handleGetKey(resp http.ResponseWriter, req *http.Request) {
 }
 
 // @Description  Retrieve the environment for an API Key or Server ID. This endpoint is designed for auth proxy requests from Nginx.
-// @Description One of X-Server, X-API-Key or X-Original-URI (with an api key in it) must be provided.
+// @Description One of X-Server, X-Api-Key or X-Original-URI (with an api key in it) must be provided.
 // @Summary      Get user or server environment
 // @Tags         auth
 // @Param        X-Server       header string false "Discord Server ID to route."
 // @Param        X-Password     header string false "Shared website secret. Required when X-Server header is provided."
-// @Param        X-API-Key      header string false "User's API Key to route. May also be provided in X-Original-URI header."
+// @Param        X-Api-Key      header string false "User's API Key to route. May also be provided in X-Original-URI header."
 // @Param        X-Original-URI header string false "User's API Key may be provided in this header at URI position 5: /api/v1/route/method/{key}"
 // @Success      200                         "Body is empty on success, check headers."
-// @Header       200 {string} X-API-Key      "API Key parsed from request."
+// @Header       200 {string} X-Api-Key      "API Key parsed from request."
 // @Header       200 {string} X-Environment  "Environment: live, dev, etc."
 // @Header       200 {string} X-Username     "Username for the user whose API key was provided."
 // @Header       200 {string} X-UserID       "MySQL ID for the user whose API key was provided."
 // @Header       200 {string} Age            "How long this information has been in the cache."
 // @Failure      401 {object} string         "invalid request"
-// @Header       401 {string} X-API-Key      "API Key parsed from request."
+// @Header       401 {string} X-Api-Key      "API Key parsed from request."
 // @Router       /auth [get]
 func (s *server) handleGetAny(resp http.ResponseWriter, req *http.Request, keyReq keyReq) {
 	var (
@@ -132,11 +131,40 @@ func (s *server) writeAuthResult(
 
 // noKeyReply returns a 401.
 func (s *server) noKeyReply(resp http.ResponseWriter, req *http.Request) {
-	resp.Header().Set("X-Api-Key", mux.Vars(req)[apiKey])
+	resp.Header().Set("X-Api-Key", apiKeyFromRequest(req))
 
-	if s.RequiresAPIKey(req.Header.Get("X-Original-Uri")) {
+	if s.RequiresAPIKey(getHeader(req.Header, "X-Original-Uri")) {
 		resp.WriteHeader(http.StatusUnauthorized)
 	} else {
 		resp.WriteHeader(http.StatusOK)
+	}
+}
+
+// handleAuth dispatches /auth by method and headers. This is our primary entry point.
+func (s *server) handleAuth(resp http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case http.MethodDelete:
+		if getHeader(req.Header, "X-Api-Keys") != "" {
+			s.handleDelKey(resp, req)
+			return
+		}
+
+		if getHeader(req.Header, "X-Server") != "" {
+			s.handleDelSrv(resp, req)
+			return
+		}
+
+		http.NotFound(resp, req)
+	case http.MethodGet, http.MethodHead:
+		if getHeader(req.Header, "X-Server") != "" && getHeader(req.Header, "X-Api-Key") == s.Password {
+			s.handleServer(resp, req)
+			return
+		}
+
+		s.parseAPIKey(http.HandlerFunc(s.handleGetKey)).ServeHTTP(resp, req)
+	case http.MethodPost, http.MethodPut:
+		s.parseAPIKey(http.HandlerFunc(s.handleGetKey)).ServeHTTP(resp, req)
+	default:
+		http.NotFound(resp, req)
 	}
 }

--- a/pkg/webserver/handlers_stats.go
+++ b/pkg/webserver/handlers_stats.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"slices"
-	"strings"
 
 	"github.com/Notifiarr/mysql-auth-proxy/docs"
-	"github.com/gorilla/mux"
 	"github.com/swaggo/swag"
 )
 
@@ -36,7 +34,7 @@ func (s *server) handeUserList(resp http.ResponseWriter, _ *http.Request) {
 // @Failure      401  {object} string "invalid request"
 // @Router       /stats/key/{key} [get]
 func (s *server) handleUserInfo(resp http.ResponseWriter, req *http.Request) {
-	err := json.NewEncoder(resp).Encode(s.users.Get(mux.Vars(req)["key"]))
+	err := json.NewEncoder(resp).Encode(s.users.Get(req.PathValue("key")))
 	if err != nil {
 		s.Printf("[ERROR] writing response: %v", err)
 	}
@@ -65,7 +63,7 @@ func (s *server) handeSrvList(resp http.ResponseWriter, _ *http.Request) {
 // @Failure      401  {object} string "invalid request"
 // @Router       /stats/server/{key} [get]
 func (s *server) handleSrvInfo(resp http.ResponseWriter, req *http.Request) {
-	err := json.NewEncoder(resp).Encode(s.servers.Get(mux.Vars(req)["key"]))
+	err := json.NewEncoder(resp).Encode(s.servers.Get(req.PathValue("key")))
 	if err != nil {
 		s.Printf("[ERROR] writing response: %v", err)
 	}
@@ -110,17 +108,11 @@ func (s *server) showConfig(resp http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *server) handlerSwaggerDoc(response http.ResponseWriter, request *http.Request) {
-	instance := strings.TrimSuffix(mux.Vars(request)["instance"], ".json")
-	if instance == "" {
-		instance = "api"
-	}
-
 	docs.SwaggerInfoapi.Version = "v0"
-
 	//	docs.SwaggerInfoapi.BasePath = c.Config.URLBase
 	docs.SwaggerInfoapi.Host = request.Host
 
-	doc, err := swag.ReadDoc(instance)
+	doc, err := swag.ReadDoc("api")
 	if err != nil {
 		http.Error(response, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/webserver/routing_test.go
+++ b/pkg/webserver/routing_test.go
@@ -1,0 +1,37 @@
+//nolint:testpackage // Tests unexported handleAuth.
+package webserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleAuth_deleteWithoutHeadersIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := &server{Config: &Config{}}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/auth", nil)
+
+	s.handleAuth(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleAuth_unknownMethodIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := &server{Config: &Config{}}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPatch, "/auth", nil)
+
+	s.handleAuth(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}

--- a/pkg/webserver/start.go
+++ b/pkg/webserver/start.go
@@ -27,6 +27,20 @@ const (
 	timeout       = 15 * time.Second
 )
 
+// Canonical HTTP Headers.
+const (
+	HeaderXAPIKey       = "X-Api-Key"  //nolint:gosec // not a cred.
+	HeaderXAPIKeys      = "X-Api-Keys" //nolint:gosec // not a cred.
+	HeaderXOriginalURI  = "X-Original-Uri"
+	HeaderXServer       = "X-Server"
+	HeaderXUsername     = "X-Username"
+	HeaderXUserid       = "X-Userid"
+	HeaderXForwardedFor = "X-Forwarded-For"
+	HeaderEnvironment   = "X-Environment"
+	HeaderContentType   = "Content-Type"
+	HeaderAge           = "Age"
+)
+
 // Config is the input data for the server.
 type Config struct {
 	*userinfo.Config // contains mysql host, user, pass, logger.
@@ -175,7 +189,7 @@ func (s *server) startWebServer() error {
 
 	s.server = &http.Server{
 		Addr:              s.ListenAddr,
-		Handler:           accessLogWrap(s.countRequests(mux), s.httpLog.Writer()),
+		Handler:           s.accessLogWrap(mux, s.httpLog.Writer()),
 		ReadTimeout:       timeout,
 		ReadHeaderTimeout: timeout,
 		WriteTimeout:      timeout,

--- a/pkg/webserver/start.go
+++ b/pkg/webserver/start.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Notifiarr/mysql-auth-proxy/docs"
 	"github.com/Notifiarr/mysql-auth-proxy/pkg/exp"
 	"github.com/Notifiarr/mysql-auth-proxy/pkg/userinfo"
-	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golift.io/cache"
 	"golift.io/cnfg"
@@ -45,7 +44,6 @@ type Config struct {
 // server holds the running data.
 type server struct {
 	*Config
-	*mux.Router
 
 	users   *cache.Cache
 	servers *cache.Cache
@@ -56,8 +54,6 @@ type server struct {
 	// noAuthMu protects NoAuthPaths on the embedded Config (RequiresAPIKey, reload, showConfig).
 	noAuthMu sync.RWMutex
 	metrics  *exp.Metrics
-	// apiKeyVarsPool backs mux.SetURLVars in parseAPIKey (avoids a map alloc per request).
-	apiKeyVarsPool sync.Pool
 }
 
 // ErrNoSQLConfig is returned if no mysql config is present.
@@ -123,8 +119,6 @@ func Start(config *Config) error {
 }
 
 func (s *server) start() error {
-	s.apiKeyVarsPool = sync.Pool{New: func() any { return make(map[string]string, 1) }}
-
 	s.users = cache.New(cache.Config{
 		PruneInterval:   pruneInterval,
 		RequestAccuracy: time.Second,
@@ -152,38 +146,36 @@ func (s *server) start() error {
 	s.Printf("HTTP listening at: %s", s.ListenAddr)
 
 	s.ui = info
-	s.Router = mux.NewRouter()
 
 	return s.startWebServer()
 }
 
 func (s *server) startWebServer() error {
-	s.Use(s.countRequests)
-	// api docs
-	s.PathPrefix("/docs/").Handler(http.StripPrefix("/docs/", http.FileServer(docs.AssetFS())))
-	s.HandleFunc("/swagger.json", s.handlerSwaggerDoc).Methods(http.MethodGet)
-	// human handlers
-	s.HandleFunc("/reload", s.reloadConfig).Methods(http.MethodGet)
-	s.HandleFunc("/stats/config", s.showConfig).Methods(http.MethodGet)
-	s.HandleFunc("/stats/keys", s.handeUserList).Methods(http.MethodGet)
-	s.HandleFunc("/stats/servers", s.handeSrvList).Methods(http.MethodGet)
-	s.HandleFunc("/stats/key/{key}", s.handleUserInfo).Methods(http.MethodGet)
-	s.HandleFunc("/stats/server/{key}", s.handleSrvInfo).Methods(http.MethodGet)
-	// delete handlers
-	s.HandleFunc("/auth", s.handleDelKey).Methods(http.MethodDelete).Headers("X-API-Keys", "")
-	s.HandleFunc("/auth", s.handleDelSrv).Methods(http.MethodDelete).Headers("X-Server", "")
-	// nginx handlers
-	s.HandleFunc("/auth", s.handleServer).Methods(http.MethodGet, http.MethodHead).
-		Headers("X-Server", "", "X-API-Key", s.Password)
-	s.Handle("/auth", s.parseAPIKey(http.HandlerFunc(s.handleGetKey))).
-		Methods(http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut)
-	s.Handle("/metrics", promhttp.Handler())
-	// default: go away
-	s.HandleFunc("/", s.noKeyReply)
+	mux := http.NewServeMux()
+	docsHandler := http.StripPrefix("/docs/", http.FileServer(docs.AssetFS()))
+	mux.Handle("GET /docs/", docsHandler)
+	mux.Handle("HEAD /docs/", docsHandler)
+	mux.HandleFunc("GET /swagger.json", s.handlerSwaggerDoc)
+	mux.HandleFunc("GET /reload", s.reloadConfig)
+	mux.HandleFunc("GET /stats/config", s.showConfig)
+	mux.HandleFunc("GET /stats/keys", s.handeUserList)
+	mux.HandleFunc("GET /stats/servers", s.handeSrvList)
+	mux.HandleFunc("GET /stats/key/{key}", s.handleUserInfo)
+	mux.HandleFunc("GET /stats/server/{key}", s.handleSrvInfo)
+	mux.HandleFunc("/auth", s.handleAuth)
+	mux.Handle("GET /metrics", promhttp.Handler())
+
+	for _, method := range []string{
+		http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodOptions,
+		http.MethodConnect, http.MethodTrace,
+	} {
+		mux.HandleFunc(method+" /{$}", s.noKeyReply)
+	}
 
 	s.server = &http.Server{
 		Addr:              s.ListenAddr,
-		Handler:           accessLogWrap(s.Router, s.httpLog.Writer()),
+		Handler:           accessLogWrap(s.countRequests(mux), s.httpLog.Writer()),
 		ReadTimeout:       timeout,
 		ReadHeaderTimeout: timeout,
 		WriteTimeout:      timeout,


### PR DESCRIPTION
- Ditches gorilla/mux.
- Removes a sync pool that was used to set a response header.
- Adds a `getHeader` method to more quickly extract header values.
- Canonicalizes all uses of header names.
- Puts all headers used into constants.
- Removes counter response writer and calls counter method from access log wrapper.